### PR TITLE
Korjaus autopep8:n asentamiseen

### DIFF
--- a/materiaali/python/pylint.md
+++ b/materiaali/python/pylint.md
@@ -97,7 +97,7 @@ Jos integroinnin kanssa ilmenee ongelmia, tutustu Visual Studio Coden [ohjeisiin
 Tiettyjen laatukorjausten, kuten sisennysten ja liian pitkien koodirivien korjaaminen tuottaa välillä turhaa manuaalista työtä. Koodin automaattisessa formatoinnissa auttaa [autopep8](https://pypi.org/project/autopep8/)-kirjasto. Kirjasto formatoi koodin automaattisesti [PEP 8](https://www.python.org/dev/peps/pep-0008/)-tyyliohjeiden mukaisesti. Aloitetaan sen käyttö asentamalle se projektin riippuvuudeksi:
 
 ```bash
-poetry install autopep8
+poetry add autopep8 --dev
 ```
 
 Tämän jälkeen voimme virtuaaliympäristössä formatoida _src_ hakemiston koodin komennolla:


### PR DESCRIPTION
Kokeillessani annettua käskyä "poetry install autopep8" asentaakseni riippuvuudeksi, tuli vain virheilmoituksena "Too many arguments".

Käyttäen samaa tapaa kuin aiemmissa ohjeistuksissa projektin riippuvuuksiksi asentamisessa, onnistui autopep8 asentaminen hyvin ja näyttäisi kokeilun pohjalta toimivankin.