### PR TITLE
maksukortti parity with course material

### DIFF
--- a/materiaali/python/unicafe/src/maksukortti.py
+++ b/materiaali/python/unicafe/src/maksukortti.py
@@ -1,5 +1,6 @@
 class Maksukortti:
     def __init__(self, saldo):
+        # saldo on senteissä
         self.saldo = saldo
 
     def lataa_rahaa(self, lisays):


### PR DESCRIPTION
The Maksukortti class in https://ohjelmistotekniikka-hy.github.io/python/viikko2 has a comment "# saldo on senteissä" making the differences to the other Maksukortti more clear.

Differences between the class shown in material and the downloaded one can cause confusion, especially since the name is reused in the part.

If this is intentional and meant to make students study the class closer, disregard the PR.