### PR TITLE
add search functionality

### DIFF
--- a/haku.html
+++ b/haku.html
@@ -1,0 +1,40 @@
+---
+layout: page
+permalink: /haku
+title: Haku
+inheader: true
+---
+
+<form action="/haku/" method="GET" style="margin-bottom: 10px">
+  <input
+    type="search"
+    name="q"
+    id="search-input"
+    placeholder="Hae materiaalista"
+    style="padding: 5px;"
+  />
+  <button
+    type="submit"
+    id="search-button"
+    style="margin-left: 10px;"
+  >
+    Hae
+  </button>
+</form>
+
+<ul id="search-results" style="list-style:none;"></ul>
+
+<script>
+  window.pages = {
+      {% for page in site.pages %}
+          "{{ page.url | slugify }}": {
+              "title": "{{ page.title | xml_escape }}",
+              "content": {{ page.content | markdownify | strip_newlines | strip_html | jsonify }},
+              "url": "{{ site.url | append: page.url | xml_escape }}",
+              "path": "{{ page.url | xml_escape }}"
+          }{% unless forloop.last %},{% endunless %}
+      {% endfor %}
+  };
+</script>
+<script src="https://unpkg.com/lunr/lunr.js"></script>
+<script src="/search.js"></script>

--- a/search.js
+++ b/search.js
@@ -1,0 +1,40 @@
+const  getQueryVariable = () => {
+  const query = window.location.search.substring(1)
+  if (!query) return null
+  const queryTerm = query.split('=')[1]
+  return decodeURIComponent(queryTerm.replace(/\+/g, '* ')) + '*'
+}
+
+const searchTerm = getQueryVariable()
+
+if (searchTerm) {
+  const searchIndex = lunr(function() {
+    this.field('title', { boost: 10 })
+    this.field('content')
+    for (let key in window.pages) {
+      if (key !== 'ohjaajan-ohje') {
+        this.add({
+          'id': key,
+          'title': pages[key].title,
+          'content': pages[key].content
+        })
+      }
+      
+    }
+  })
+  
+  const results = searchIndex.search(searchTerm + '*')
+  const resultPages = results.map((match) => pages[match.ref])
+  
+  let resultsString = ''
+  resultPages.forEach((r) => {
+    resultsString += "<li>"
+    resultsString += "<a class='result' href='" + r.url + "'><h3>" + r.title + "</h3></a>"
+    let foundSpot = r.content.search(searchTerm)
+    if (foundSpot === -1) foundSpot = 0
+    resultsString += "<div class='snippet'>" + r.content.substring(foundSpot, foundSpot+200) + "</div>"
+    resultsString += "</li>"
+  })
+  
+  document.querySelector("#search-results").innerHTML = resultsString
+}


### PR DESCRIPTION
Adds the possibility to globally search from the material. Since the material can sometimes be a bit hard to navigate, this should be a useful feature.

Uses [lunr.js](https://lunrjs.com) to do the actual search by creating a search index from all of the sites pages. The search uses [wildcard](https://lunrjs.com/guides/searching.html#wildcards) search that matches all results that start with the search query, [see here](https://github.com/makeri89/ohjelmistotekniikka-hy.github.io/blob/9d3ef372316e7aefb70e94a7bfe02a1be876ac80/search.js#L5).