### PR TITLE
Imports should be ignored for similarity checks

### DIFF
--- a/materiaali/python/.pylintrc
+++ b/materiaali/python/.pylintrc
@@ -354,7 +354,7 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
-ignore-imports=no
+ignore-imports=yes
 
 # Minimum lines number of a similarity.
 min-similarity-lines=4


### PR DESCRIPTION
... because complaining about similar imports in multiple source files makes absolutely no sense at all. The idea of imports is to literally import things, so by definition this will lead to similar lines in multiple files -- which is something usually desired, as this makes it easier to avoid duplicating actual code.