### PR TITLE
VS Code:in debugging (F5) + poetry deps

### DIFF
--- a/materiaali/python/viikko2.md
+++ b/materiaali/python/viikko2.md
@@ -205,6 +205,8 @@ python3 src/index.py
 
 Voimme lähteä virtuaaliympäristöstä komennolla `exit`.
 
+Poetry:n tuodut riippuvuudet ovat vain virtuaalisessa ympäristössä saatavilla, VS Code:in sisäänrakennettu "debugging mode" (F5 oletuksena) ei välttämättä toimi. Koita ensin `poetry shell` ja vasta sen jälkeen käynnistä VS Code `code /path/to/projekt` komennolla.
+
 ### Kehityksen aikaiset riippuvuudet
 
 Poetryn avulla riippuvuuksia on mahdollista ryhmitellä niiden käyttötarkoituksen mukaan. Melko yleinen tapa ryhmitellä riippuuvuuksia on ryhmitellä ne _kehityksen_ ja _suorituksen_ aikaisiksi riippuvuuksiksi. Kehityksen aikaisia riippuvuuksia tarvitaan ohjelmiston kehityksen aikana, mutta ne eivät ole välttämättömiä ohjelman suorituksessa.


### PR DESCRIPTION
debugging fails if `poetry shell` is initiated from within a VS Code terminal, modules are not found. on the other hand, if first we enter the `poetry shell` and only then we launch VS Code, the dependencies are visible to VS Code as well, hence debugging works.